### PR TITLE
Replace #send with #method

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -15,7 +15,7 @@ module BestInPlace
 
       display_value = best_in_place_build_value_for(real_object, field, opts)
 
-      value = real_object.send(field)
+      value = real_object.method(field).call
 
       if opts[:collection] or type == :checkbox
         collection = opts[:collection]


### PR DESCRIPTION
Using #send is dangerous. So, my suggestion would be using #method to retain the boundary of callable method.